### PR TITLE
Fix deployment issues for vercel

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,15 @@ const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  experimental: {
+    serverActions: true,
+    serverComponentsExternalPackages: [
+      "cloudinary",
+      "nodemailer",
+      "razorpay",
+      "stripe",
+    ],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Configure Next.js for Vercel deployment.

Enabled experimental Server Actions for Vercel build compilation and marked Node-only libraries (`cloudinary`, `nodemailer`, `razorpay`, `stripe`) as external for correct bundling on Vercel.